### PR TITLE
Fix status command exit code for running services (fixes #1110)

### DIFF
--- a/src/WinSW/Program.cs
+++ b/src/WinSW/Program.cs
@@ -786,6 +786,7 @@ namespace WinSW
                     context.ExitCode = svc.Status switch
                     {
                         ServiceControllerStatus.Stopped => 0,
+                        ServiceControllerStatus.Running => 0,
                         _ => 1
                     };
                 }


### PR DESCRIPTION
Previously, the `status` command returned exit code 1 for a service in the `Running` state. This caused scripts and monitoring tools to treat a healthy service as an error.

Updated the status logic to return exit code 0 for both `Stopped` and `Running` states, and 1 for all other states.
